### PR TITLE
Fix url-download

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -10,7 +10,7 @@ var isWin = (process.platform === 'win32' || process.env.NODE_PLATFORM === 'wind
 var defaultBin = path.join(__dirname, '../../..', 'bin', 'youtube-dl');
 var defaultPath = path.join(defaultBin, 'details');
 var regexp = /https:\/\/yt-dl\.org\/downloads\/(\d{4}\.\d\d\.\d\d(\.\d)?)\/youtube-dl/;
-var url = 'https://rg3.github.io/youtube-dl/download.html';
+var url = 'https://ytdl-org.github.io/youtube-dl/download.html';
 
 function download(link, callback) {
 


### PR DESCRIPTION
Fix error of download youtube-dl, required in PowderPlayer for work, screenshot ->  https://ibb.co/QPLbPny

----------------------------------------------------------------------------------------------------------------
> youtube-dl@1.11.2 postinstall /home/linux/PowderPlayer/node_modules/youtube-dl
> node ./scripts/download.js
Error: Could not find download link in https://rg3.github.io/youtube-dl/download.html
    at Request.get [as _callback] (/home/linux/PowderPlayer/node_modules/youtube-dl/lib/downloader.js:64:31)
    at Request.self.callback (/home/linux/PowderPlayer/node_modules/youtube-dl/node_modules/request/request.js:200:22)...